### PR TITLE
Testrtc wifi scan

### DIFF
--- a/samples/web/.jshintrc
+++ b/samples/web/.jshintrc
@@ -10,6 +10,7 @@
   "undef": true,
   "unused": "strict",
   "globals": {
+    "addExplicitTest": true,
     "addTest": true,
     "arrayAverage": true,
     "arrayMax": true,

--- a/samples/web/content/testrtc/js/bandwidth_test.js
+++ b/samples/web/content/testrtc/js/bandwidth_test.js
@@ -162,3 +162,45 @@ function testVideoBandwidth(config) {
     testFinished();
   }
 }
+
+addExplicitTest('Connectivity', 'WiFi Periodic Scan',
+  Call.asyncCreateTurnConfig.bind(null, testForWiFiPeriodicScan, reportFatal));
+
+function testForWiFiPeriodicScan(config) {
+  var testDurationMs = 5 * 60 * 1000;
+  var sendIntervalMs = 100;
+  var testFinished = false;
+  var delays = [];
+  var call = new Call(config);
+  call.setIceCandidateFilter(Call.isRelay);
+
+  var senderChannel = call.pc1.createDataChannel(null);
+  senderChannel.addEventListener('open', send);
+  call.pc2.addEventListener('datachannel', onReceiverChannel);
+  call.establishConnection();
+
+  setTimeoutWithProgressBar(finishTest, testDurationMs);
+
+  function onReceiverChannel(event) {
+     event.channel.addEventListener('message', receive);
+  }
+
+  function send() {
+    if (testFinished) { return; }
+    senderChannel.send('' + Date.now());
+    setTimeout(send, sendIntervalMs);
+  }
+
+  function receive(event) {
+    if (testFinished) { return; }
+    var sendTime = parseInt(event.data);
+    var delay = Date.now() - sendTime;
+    delays.push(delay);
+  }
+
+  function finishTest() {
+    report.traceEventInstant('periodic-delay', { delays: delays });
+    testFinished = true;
+    testFinished();
+  }
+}

--- a/samples/web/content/testrtc/js/bandwidth_test.js
+++ b/samples/web/content/testrtc/js/bandwidth_test.js
@@ -204,6 +204,20 @@ function testForWiFiPeriodicScan(config) {
     report.traceEventInstant('periodic-delay', { delays: delays, recvTimeStamps: recvTimeStamps });
     running = false;
     call.close();
+
+    var avg = arrayAverage(delays);
+    var max = arrayMax(delays);
+    var min = arrayMin(delays);
+
+    reportInfo('Average delay: ' + avg + ' ms.');
+    reportInfo('Min delay: ' + min + ' ms.');
+    reportInfo('Max delay: ' + max + ' ms.');
+
+    if (max / (min + 100) < 2.0) {
+      reportSuccess('All seems fine.');
+    } else {
+      reportError('There is a big difference between the min and max delay of packets. Your network appears unstable.');
+    }
     testFinished();
   }
 }

--- a/samples/web/content/testrtc/js/main.js
+++ b/samples/web/content/testrtc/js/main.js
@@ -260,6 +260,14 @@ function addTest(suiteName, testName, func) {
   testSuites.push(testSuite);
 }
 
+// Add a test that only runs if it is explicitly enabled with
+// ?test_filter=<TEST NAME>
+function addExplicitTest(suiteName, testName, func) {
+  if (testIsExplicitlyEnabled(testName)) {
+    addTest(suiteName, testName, func);
+  }
+}
+
 // Helper to run a list of tasks sequentially:
 //   tasks - Array of { run: function(doneCallback) {} }.
 //   doneCallback - called once all tasks have run sequentially.
@@ -361,13 +369,16 @@ function testIsDisabled(testName) {
   if (testFilters.length === 0) {
     return false;
   }
+  return !testIsExplicitlyEnabled(testName);
+}
 
+function testIsExplicitlyEnabled(testName) {
   for (var i = 0; i !== testFilters.length; ++i) {
     if (testFilters[i] === testName) {
-      return false;
+      return true;
     }
   }
-  return true;
+  return false;
 }
 
 // Return the first audio device label on the track.

--- a/samples/web/content/testrtc/js/main.js
+++ b/samples/web/content/testrtc/js/main.js
@@ -7,7 +7,7 @@
  */
 
 /* More information about these options at jshint.com/docs/options */
-/* exported addTest, doGetUserMedia, reportInfo, expectEquals, testFinished, start, setTestProgress, audioContext, reportSuccess, reportError, settingsDialog, setTimeoutWithProgressBar */
+/* exported addExplicitTest, addTest, doGetUserMedia, reportInfo, expectEquals, testFinished, start, setTestProgress, audioContext, reportSuccess, reportError, settingsDialog, setTimeoutWithProgressBar */
 'use strict';
 
 // Global WebAudio context that can be shared by all tests.

--- a/samples/web/content/testrtc/js/report.js
+++ b/samples/web/content/testrtc/js/report.js
@@ -32,6 +32,7 @@ Report.prototype = {
     var content = encodeURIComponent(this.getContent_());
     var link = document.createElement('a');
     link.setAttribute('href', 'data:text/plain;charset=utf-8,' + content);
+    link.setAttribute('download', 'testrtc-' + (new Date().toJSON()) + '.log');
     link.click();
   },
 


### PR DESCRIPTION
Add a test for detecting wifi scans that periodically inject delays into the channels due to the network card stop to scan all other frequencies in a go.

The test is based on measuring delay suffered by a low rate 10Hz data stream when looped back via a TURN server. For now the test has no expectations and due to its delay nature it is only enabled when explicitely enabling it with: "?test_filter=WiFi Periodic Scan".

Plan is to push this into prod and ask for a few reports to write the expectations based on.