### PR TITLE
Update capture extension instructions to reload over https.

### DIFF
--- a/samples/web/content/manual-test/peer2peer/js/main.js
+++ b/samples/web/content/manual-test/peer2peer/js/main.js
@@ -387,7 +387,7 @@ function screenCaptureExtensionHandler_() {
                         '3. Click: "Load the unpacked extension..."\n' +
                         '4. Choose "extension" folder from the repository:\n' +
                         '(Can be downloaded from here http://goo.gl/M1zRbn)\n' +
-                        '5. Reload this page';
+                        '5. Reload this page over https';
           alert(message);
         }
         window.postMessage({ type: 'SS_UI_REQUEST', text: 'start' }, '*');


### PR DESCRIPTION
This is necessary because the extension seems to fail if the page is loaded over http.