### PR TITLE
Logging peer connection config for loopback calls.

### DIFF
--- a/samples/web/content/testrtc/js/call.js
+++ b/samples/web/content/testrtc/js/call.js
@@ -9,7 +9,7 @@
 
 function Call(config) {
   this.traceEvent = report.traceEventAsync('call');
-  this.traceEvent({ config : config });
+  this.traceEvent({ config: config });
 
   this.pc1 = new RTCPeerConnection(config);
   this.pc2 = new RTCPeerConnection(config);

--- a/samples/web/content/testrtc/js/call.js
+++ b/samples/web/content/testrtc/js/call.js
@@ -8,6 +8,9 @@
 'use strict';
 
 function Call(config) {
+  this.traceEvent = report.traceEventAsync('call');
+  this.traceEvent({ config : config });
+
   this.pc1 = new RTCPeerConnection(config);
   this.pc2 = new RTCPeerConnection(config);
 
@@ -19,10 +22,12 @@ function Call(config) {
 
 Call.prototype = {
   establishConnection: function () {
+    this.traceEvent({ state: 'start' });
     this.pc1.createOffer(this.gotOffer_.bind(this));
   },
 
   close: function () {
+    this.traceEvent({ state: 'end' });
     this.pc1.close();
     this.pc2.close();
   },


### PR DESCRIPTION
This will allow to see which turn server got selected. (At the moment suspecting that when hitting a bad turn server strange delays can be seen).