### PR TITLE
WiFi periodic scan test now runs with both svrrflx and relay candidates.

### DIFF
--- a/samples/web/content/testrtc/js/bandwidth_test.js
+++ b/samples/web/content/testrtc/js/bandwidth_test.js
@@ -215,7 +215,7 @@ function testForWiFiPeriodicScan(candidateFilter, config) {
     reportInfo('Min delay: ' + min + ' ms.');
     reportInfo('Max delay: ' + max + ' ms.');
 
-    if (delays.lenght < 0.8 * testDurationMs / sendIntervalMs) {
+    if (delays.length < 0.8 * testDurationMs / sendIntervalMs) {
       reportError('Not enough samples gathered. Keep the page on the foreground while the test is running.');
     } else {
       reportSuccess('Collected ' + delays.length + ' delay samples.');

--- a/samples/web/content/testrtc/js/call.js
+++ b/samples/web/content/testrtc/js/call.js
@@ -110,6 +110,10 @@ Call.isRelay = function (candidate) {
   return candidate.type === 'relay';
 };
 
+Call.isNotHostCandidate = function (candidate) {
+  return candidate.type !== 'host';
+};
+
 Call.isIpv6 = function (candidate) {
   return candidate.address.indexOf(':') !== -1;
 };


### PR DESCRIPTION
Test with only turn candidates also left in for further investigation.
Added check for min number of samples as if the page is not on the foreground the JS setTimeout only triggers once a second.