### PR TITLE
move maybefixturnconfiguration to firefox part

### DIFF
--- a/samples/web/js/adapter.js
+++ b/samples/web/js/adapter.js
@@ -33,18 +33,6 @@ function trace(text) {
   }
 }
 
-function maybeFixConfiguration(pcConfig) {
-  if (!pcConfig) {
-    return;
-  }
-  for (var i = 0; i < pcConfig.iceServers.length; i++) {
-    if (pcConfig.iceServers[i].hasOwnProperty('urls')) {
-      pcConfig.iceServers[i].url = pcConfig.iceServers[i].urls;
-      delete pcConfig.iceServers[i].urls;
-    }
-  }
-}
-
 if (navigator.mozGetUserMedia) {
   console.log('This appears to be Firefox');
 
@@ -56,7 +44,14 @@ if (navigator.mozGetUserMedia) {
   // The RTCPeerConnection object.
   RTCPeerConnection = function(pcConfig, pcConstraints) {
     // .urls is not supported in FF yet.
-    maybeFixConfiguration(pcConfig);
+    if (pcConfig && pcConfig.iceServers) {
+      for (var i = 0; i < pcConfig.iceServers.length; i++) {
+        if (pcConfig.iceServers[i].hasOwnProperty('urls')) {
+          pcConfig.iceServers[i].url = pcConfig.iceServers[i].urls;
+          delete pcConfig.iceServers[i].urls;
+        }
+      }
+    }
     return new mozRTCPeerConnection(pcConfig, pcConstraints);
   };
 


### PR DESCRIPTION
maybeFixConfiguration is only used in Firefox now (the Chrome backward compat for non-urls was removed a while ago), so moved it there and removed the function call.

Also adds check for pcConfig.iceServers