### PR TITLE
Changed Import to import

### DIFF
--- a/samples/web/content/testrtc/index.html
+++ b/samples/web/content/testrtc/index.html
@@ -23,7 +23,7 @@
   <script src="bower_components/webcomponentsjs/webcomponents.js"></script>
   <link rel="import" href="bower_components/core-toolbar/core-toolbar.html">
   <link rel="import" href="bower_components/core-icon/core-icon.html">
-  <link rel="Import" href="bower_components/core-icons/av-icons.html">
+  <link rel="import" href="bower_components/core-icons/av-icons.html">
   <link rel="import" href="bower_components/core-collapse/core-collapse.html">
   <link rel="import" href="bower_components/paper-dialog/paper-dialog.html">
   <link rel="import" href="bower_components/paper-dialog/paper-action-dialog.html">


### PR DESCRIPTION
Safari and internet explorer are more strict hence Import with capitol "i" causes polymer never to finish importing. Firefox and Chrome assumes lowercase and it works fine.

Partly Fixes #344.