### PR TITLE
Add check for webrtc components in gumhandler.js

### DIFF
--- a/samples/web/.jshintrc
+++ b/samples/web/.jshintrc
@@ -42,7 +42,6 @@
     "setTestProgress": true,
     "setTimeoutWithProgressBar": true,
     "Ssim": true,
-    "startButton": true,
     "StatisticsAggregate": true,
     "testFinished": true,
     "trace": true,

--- a/samples/web/content/testrtc/index.html
+++ b/samples/web/content/testrtc/index.html
@@ -47,7 +47,7 @@
     <span flex>WebRTC Troubleshooter</span>
     <paper-icon-button icon="menu" onclick="settingsDialog.toggle()"></paper-icon-button>
     <paper-icon-button icon="bug-report" onclick="report.open()"></paper-icon-button>
-    <paper-button id="start-button" onclick="start()" raised>Start</paper-button>
+    <paper-button id="start-button" onclick="start()" raised disabled>Start</paper-button>
   </core-toolbar>
 
   <!-- Placeholder for dynamically generated test suites. -->

--- a/samples/web/content/testrtc/index.html
+++ b/samples/web/content/testrtc/index.html
@@ -72,6 +72,14 @@
     <paper-icon-button icon="bug-report" onclick="report.open()">File a bug</paper-icon-button>
   </paper-dialog>
 
+  <!-- GetUserMedia not supported dialog -->
+  <paper-dialog id="gum-not-supported-dialog"
+                heading="Welcome to WebRTC Troubleshooter"
+                backdrop autoCloseDisabled>
+    <p>GetUserMedia is not supported in your browser, please use a WebRTC
+      enabled browser listed at <a href="http://www.webrtc.org">http://www.webrtc.org</a>.</p>
+  </paper-dialog>
+
   <!-- Settings dialog -->
   <paper-dialog id="settings-dialog" heading="Settings" transition="paper-dialog-transition-center">
     <div class="select"><label>Audio source: <select id="audioSource"></select></label></div>

--- a/samples/web/content/testrtc/js/gumhandler.js
+++ b/samples/web/content/testrtc/js/gumhandler.js
@@ -16,11 +16,12 @@ function GumHandler() {
   this.gumNotSupportedDialog_ = document.getElementById('gum-not-supported-dialog');
   this.gumErrorMessage_ = document.getElementById('gum-error-message');
   this.firstUserCheck_ = null;
+  this.gumStreamSuccessCallback_ = null;
 }
 
 GumHandler.prototype = {
   start: function(callback) {
-    this.gumStreamSuccessCallback = callback;
+    this.gumStreamSuccessCallback_ = callback;
     if (typeof navigator.getUserMedia === 'undefined') {
       this.gumNotSupportedDialog_.open();
     } else {
@@ -47,7 +48,7 @@ GumHandler.prototype = {
     }
     this.gumPendingDialog_.close();
     this.gumErrorDialog_.close();
-    this.gumStreamSuccessCallback();
+    this.gumStreamSuccessCallback_();
   },
 
   gotError_: function(error) {

--- a/samples/web/content/testrtc/js/gumhandler.js
+++ b/samples/web/content/testrtc/js/gumhandler.js
@@ -21,11 +21,9 @@ function GumHandler() {
 GumHandler.prototype = {
   start: function(callback) {
     this.gumStreamSuccessCallback = callback;
-    startButton.disabled = true;
     if (typeof navigator.getUserMedia === 'undefined') {
       this.gumNotSupportedDialog_.open();
     } else {
-      // getSources is currently shimmed in adapter.js.
       this.getUserMedia_(callback);
       this.firstUserCheck_ = setTimeout(this.firstTimeUser_.bind(this), 300);
     }

--- a/samples/web/content/testrtc/js/gumhandler.js
+++ b/samples/web/content/testrtc/js/gumhandler.js
@@ -13,15 +13,22 @@
 function GumHandler() {
   this.gumPendingDialog_ = document.getElementById('gum-pending-dialog');
   this.gumErrorDialog_ = document.getElementById('gum-error-dialog');
+  this.gumNotSupportedDialog_ = document.getElementById('gum-not-supported-dialog');
   this.gumErrorMessage_ = document.getElementById('gum-error-message');
   this.firstUserCheck_ = null;
 }
 
 GumHandler.prototype = {
-  start: function() {
+  start: function(callback) {
+    this.gumStreamSuccessCallback = callback;
     startButton.disabled = true;
-    this.getUserMedia_();
-    this.firstUserCheck_ = setTimeout(this.firstTimeUser_.bind(this), 300);
+    if (typeof navigator.getUserMedia === 'undefined') {
+      this.gumNotSupportedDialog_.open();
+    } else {
+      // getSources is currently shimmed in adapter.js.
+      this.getUserMedia_(callback);
+      this.firstUserCheck_ = setTimeout(this.firstTimeUser_.bind(this), 300);
+    }
   },
 
   firstTimeUser_: function() {
@@ -42,7 +49,7 @@ GumHandler.prototype = {
     }
     this.gumPendingDialog_.close();
     this.gumErrorDialog_.close();
-    startButton.removeAttribute('disabled');
+    this.gumStreamSuccessCallback();
   },
 
   gotError_: function(error) {

--- a/samples/web/content/testrtc/js/main.js
+++ b/samples/web/content/testrtc/js/main.js
@@ -33,7 +33,11 @@ var currentTest;
 window.addEventListener('polymer-ready', function() {
   var gum = new GumHandler();
   gum.start(function () {
-    MediaStreamTrack.getSources(gotSources);
+    if (typeof MediaStreamTrack.getSources === 'undefined') {
+      console.log('getSources is not supported, device selection not possible.');
+    } else {
+      MediaStreamTrack.getSources(gotSources);
+    }
     startButton.removeAttribute('disabled');
   });
 });

--- a/samples/web/content/testrtc/js/main.js
+++ b/samples/web/content/testrtc/js/main.js
@@ -32,7 +32,10 @@ var currentTest;
 
 window.addEventListener('polymer-ready', function() {
   var gum = new GumHandler();
-  gum.start();
+  gum.start(function () {
+    MediaStreamTrack.getSources(gotSources);
+    startButton.removeAttribute('disabled');
+  });
 });
 
 // A test suite is a composition of many tests.
@@ -362,12 +365,6 @@ function appendOption(sourceInfo, option) {
   } else {
     console.log('Some other kind of source');
   }
-}
-
-if (typeof MediaStreamTrack === 'undefined') {
-  reportFatal('This browser does not support MediaStreamTrack.\n Try Chrome Canary.');
-} else {
-  MediaStreamTrack.getSources(gotSources);
 }
 
 function testIsDisabled(testName) {


### PR DESCRIPTION
Added check for navigator.getusermedia if not supported an error is present to the user.
Changed the startbutton to be disabled by default in HTML.

Fixes #342.

Note: On IE , Safari and Firefox the error (all paper-dialogs essentially) dialog is presented in the middle of the screen while on Chrome it's presented at the top. 