### PR TITLE
Add input and sent FPS to camresolutiontest.js

### DIFF
--- a/samples/web/content/testrtc/js/camresolutionstest.js
+++ b/samples/web/content/testrtc/js/camresolutionstest.js
@@ -126,16 +126,16 @@ CamResolutionsTest.prototype = {
     var minFPSSent = arrayMin(googAvgFrameRateSent);
     var maxFPSSent = arrayMax(googAvgFrameRateSent);
     report.traceEventInstant('video-stats', { width: currentRes[0],
-                                               height: currentRes[1],
-                                               minEncodeMs: minEncodeMs,
-                                               maxEncodeMs: maxEncodeMs,
-                                               avgEncodeMs: avgEncodeMs,
-                                               minFPSInput: minFPSInput,
-                                               maxFPSInput: maxFPSInput,
-                                               avgFPSInput: avgFPSInput,
-                                               minFPSSent: minFPSSent,
-                                               maxFPSSent: maxFPSSent,
-                                               avgFPSSent: avgFPSSent });
+                                              height: currentRes[1],
+                                              minEncodeMs: minEncodeMs,
+                                              maxEncodeMs: maxEncodeMs,
+                                              avgEncodeMs: avgEncodeMs,
+                                              minFPSInput: minFPSInput,
+                                              maxFPSInput: maxFPSInput,
+                                              avgFPSInput: avgFPSInput,
+                                              minFPSSent: minFPSSent,
+                                              maxFPSSent: maxFPSSent,
+                                              avgFPSSent: avgFPSSent });
 
     if (googAvgEncodeTime.length === 0) {
       reportError('No stats collected. Check your camera.');
@@ -143,6 +143,9 @@ CamResolutionsTest.prototype = {
       reportInfo('Encode time (ms): ' + minEncodeMs + ' min / ' + avgEncodeMs + ' avg / ' + maxEncodeMs + ' max');
       reportInfo('Input FPS: ' + minFPSInput + ' min / ' + avgFPSInput + ' avg / ' + maxFPSInput + ' max');
       reportInfo('Sent FPS: ' + minFPSSent + ' min / ' + avgFPSSent + ' avg / ' + maxFPSSent + ' max');
+      if (avgFPSSent < 5) {
+        reportError('Low average sent FPS: ' + avgFPSSent);
+      }
     }
     this.finishTestOrRetrigger_();
   },


### PR DESCRIPTION
Added googFrameRateInput and googFrameRateSent stats.
Increased the gatherStats interval to 1000ms to make sure getStats does not affect the performance.

Fixes #365 

Note:
Mac camera teardown is unpredictable and flaky on Chrome hence this test will most likely fail on Mac's. Hopefully it will be fixed soon. In the meantime, as a workaround you can have an apprtc tab open with the camera opened in HD while running TestRTC. This is not an elegant solution and it might even not give accurate stats but we do not want to create a workaround for a Chrome bug on TestRTC.