### PR TITLE
Fix jstdPhantom test errors - #367

### DIFF
--- a/samples/web/content/apprtc/appwindow.html
+++ b/samples/web/content/apprtc/appwindow.html
@@ -23,17 +23,16 @@
   
   <div id="videos">
     <video id="mini-video" autoplay muted></video>
-    <canvas id="remote-canvas"></canvas>
     <video id="remote-video" autoplay></video>
     <video id="local-video" autoplay muted></video>
   </div>
 
   <footer id="footer">
-    <div id="sharing">
-      <div>Waiting for someone to join this room: <a id="room-link" href="" target="_blank"></a></div>
+    <div id="sharing-div">
+      <div id="room-link">Waiting for someone to join this room: <a id="room-link-href" href="" target="_blank"></a></div>
     </div>
-    <div id="info"></div>
-    <div id="status"></div>
+    <div id="info-div"></div>
+    <div id="status-div"></div>
   </footer>
   
   <div id="icons" class="hidden">
@@ -73,14 +72,15 @@
   </div>
 
   <script src="/js/stats.js"></script>
-  <!-- {{ include_loopback_js }} -->
-  <script src="/js/signaling.js"></script>
-  <script src="/js/infobox.js"></script>
-  <script src="/js/sdputils.js"></script>
   <script src="/js/util.js"></script>
-  <script src="/js/main.js"></script>
-  <!-- {{ include_vr_js }} -->
   <script src="/js/adapter.js"></script>
+  <!-- {{ include_loopback_js }} -->
+  <script src="/js/signalingchannel.js"></script>
+  <script src="/js/sdputils.js"></script>
+  <script src="/js/peerconnectionclient.js"></script>
+  <script src="/js/call.js"></script>
+  <script src="/js/infobox.js"></script>
+  <script src="/js/appcontroller.js"></script>
   <script src="/js/appwindow.js"></script>
 
 </body>

--- a/samples/web/content/apprtc/js/appcontroller.js
+++ b/samples/web/content/apprtc/js/appcontroller.js
@@ -106,6 +106,8 @@ var AppController = function(params) {
   $(UI_CONSTANTS.muteVideoSvg).onclick = this.toggleVideoMute_.bind(this);
   $(UI_CONSTANTS.fullscreenSvg).onclick = this.toggleFullScreen_.bind(this);
   $(UI_CONSTANTS.hangupSvg).onclick = this.hangup_.bind(this);
+  
+  setUpFullScreen();
 };
 
 AppController.prototype.hangup_ = function() {

--- a/samples/web/content/apprtc/js/appcontroller.js
+++ b/samples/web/content/apprtc/js/appcontroller.js
@@ -8,7 +8,7 @@
 
 /* More information about these options at jshint.com/docs/options */
 
-/* globals trace, InfoBox, isFullScreen */
+/* globals trace, InfoBox, setUpFullScreen, isFullScreen */
 /* exported AppController, remoteVideo */
 
 'use strict';

--- a/samples/web/content/apprtc/js/appwindow.js
+++ b/samples/web/content/apprtc/js/appwindow.js
@@ -8,7 +8,7 @@
 
 /* More information about these options at jshint.com/docs/options */
 // Variables defined in and used from main.js.
-/* globals randomString, initialize */
+/* globals randomString, AppController */
 /* exported params */
 'use strict';
 
@@ -67,4 +67,4 @@ var joinRoomLink = document.querySelector('#room-link-href');
 joinRoomLink.href = params.roomLink;
 joinRoomLink.text = params.roomLink;
 
-var appController = new AppController(params);
+new AppController(params);

--- a/samples/web/content/apprtc/js/appwindow.js
+++ b/samples/web/content/apprtc/js/appwindow.js
@@ -61,10 +61,12 @@ var params = {
 // Generate random room id and connect.
 params.roomId = randomString(9);
 params.roomLink =  'https://apprtc.appspot.com/room/' + params.roomId;
-params.roomServer = 'https://apprtc.appspot.com';
+params.server = 'https://apprtc.appspot.com';
 
-var joinRoomLink = document.querySelector('#room-link');
-joinRoomLink.href = params.roomLink;
-joinRoomLink.text = params.roomLink;
+var joinRoomLink = document.querySelector('#room-link-href');
+if (joinRoomLink) {
+  joinRoomLink.href = params.roomLink;
+  joinRoomLink.text = params.roomLink;
+}
 
-initialize();
+var appController = new AppController(params);

--- a/samples/web/content/apprtc/js/appwindow.js
+++ b/samples/web/content/apprtc/js/appwindow.js
@@ -61,12 +61,10 @@ var params = {
 // Generate random room id and connect.
 params.roomId = randomString(9);
 params.roomLink =  'https://apprtc.appspot.com/room/' + params.roomId;
-params.server = 'https://apprtc.appspot.com';
+params.roomServer = 'https://apprtc.appspot.com';
 
 var joinRoomLink = document.querySelector('#room-link-href');
-if (joinRoomLink) {
-  joinRoomLink.href = params.roomLink;
-  joinRoomLink.text = params.roomLink;
-}
+joinRoomLink.href = params.roomLink;
+joinRoomLink.text = params.roomLink;
 
 var appController = new AppController(params);

--- a/samples/web/content/apprtc/js/call.js
+++ b/samples/web/content/apprtc/js/call.js
@@ -18,7 +18,7 @@
 
 var Call = function(params) {
   this.params_ = params;
-  this.roomServer_ = params.server || '';
+  this.roomServer_ = params.roomServer || '';
 
   this.channel_ = new SignalingChannel(params.wssUrl, params.wssPostUrl);
   this.channel_.onmessage = this.onRecvSignalingChannelMessage_.bind(this);

--- a/samples/web/content/apprtc/js/testpolyfills.js
+++ b/samples/web/content/apprtc/js/testpolyfills.js
@@ -128,3 +128,24 @@ MyPromise.prototype.onReject_ = function(reason) {
 };
 
 window.Promise = window.Promise || MyPromise;
+
+// Provide a shim for phantomjs, where chrome is not defined.
+var myChrome = {
+  app: {
+    runtime: {
+      onLaunched: {
+        addListener: function(callback) {
+          console.log('chrome.app.runtime.onLaunched.addListener called:' + JSON.stringify(callback));
+        }
+      }
+    },
+    window: {
+      create: function(fileName, callback) {
+        console.log('chrome.window.create called: ' + fileName + ', ' + JSON.stringify(callback));
+      }
+    }
+  }
+};
+
+window.chrome = window.chrome || myChrome;
+

--- a/samples/web/content/apprtc/js/util.js
+++ b/samples/web/content/apprtc/js/util.js
@@ -8,7 +8,8 @@
 
 /* More information about these options at jshint.com/docs/options */
 
-/* exported fullScreenElement, isFullScreen, requestTurnServers, sendAsyncUrlRequest, randomString */
+/* exported setUpFullScreen, fullScreenElement, isFullScreen, 
+   requestTurnServers, sendAsyncUrlRequest, randomString */
 
 'use strict';
 

--- a/samples/web/content/apprtc/js/util.js
+++ b/samples/web/content/apprtc/js/util.js
@@ -85,14 +85,15 @@ function filterTurnUrls(urls, protocol) {
 }
 
 // Start shims for fullscreen
-
-document.cancelFullScreen = document.webkitCancelFullScreen ||
-document.mozCancelFullScreen || document.cancelFullScreen;
-if (document.body) {
+function setUpFullScreen() {
+  document.cancelFullScreen = document.webkitCancelFullScreen ||
+  document.mozCancelFullScreen || document.cancelFullScreen;
+  
   document.body.requestFullScreen = document.body.webkitRequestFullScreen ||
   document.body.mozRequestFullScreen || document.body.requestFullScreen;
+
+  document.onfullscreenchange = document.onwebkitfullscreenchange = document.onmozfullscreenchange;
 }
-document.onfullscreenchange = document.onwebkitfullscreenchange = document.onmozfullscreenchange;
 
 function isFullScreen(){
   return !!(document.webkitIsFullScreen || document.mozFullScreen ||

--- a/samples/web/content/apprtc/js/util.js
+++ b/samples/web/content/apprtc/js/util.js
@@ -88,10 +88,10 @@ function filterTurnUrls(urls, protocol) {
 
 document.cancelFullScreen = document.webkitCancelFullScreen ||
 document.mozCancelFullScreen || document.cancelFullScreen;
-
-document.body.requestFullScreen = document.body.webkitRequestFullScreen ||
-document.body.mozRequestFullScreen || document.body.requestFullScreen;
-
+if (document.body) {
+  document.body.requestFullScreen = document.body.webkitRequestFullScreen ||
+  document.body.mozRequestFullScreen || document.body.requestFullScreen;
+}
 document.onfullscreenchange = document.onwebkitfullscreenchange = document.onmozfullscreenchange;
 
 function isFullScreen(){

--- a/samples/web/content/apprtc/js_test_driver.conf
+++ b/samples/web/content/apprtc/js_test_driver.conf
@@ -1,7 +1,28 @@
 server: http://localhost:9876
 
+# The order of these files is important and should match
+# the order they are loaded in index.html.
+# The wildcard match *.js should catch any newly added files.
 load:
+  - js/testpolyfills.js
+  - js/stats.js
+  - js/util.js
+  - js/adapter.js
+  - js/loopback.js
+  - js/signalingchannel.js
+  - js/sdputils.js
+  - js/peerconnectionclient.js
+  - js/call.js
+  - js/infobox.js
+  - js/appcontroller.js
+  - js/background.js
   - js/*.js
+
+# appwindow.js is the Chrome App equivalent of index.html
+# and builds up the entire app. The tests don't currently
+# load any html, which breaks much of the code.
+exclude:
+  - js/appwindow.js
 
 test:
   - js/*_test.js


### PR DESCRIPTION
Fixes issue #367.

The environment in which the jstd tests run is different from the full
web browser. Anything that uses html elements directly and is executed
when a js file is loaded needs to be null checked.

@jiayliu 