### PR TITLE
Use params returned from /register call

### DIFF
--- a/samples/web/content/apprtc/apprtc.py
+++ b/samples/web/content/apprtc/apprtc.py
@@ -245,11 +245,6 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
   username = client_id if client_id is not None else generate_random(9)
   if len(turn_base_url) > 0:
     turn_url = constants.TURN_URL_TEMPLATE % (turn_base_url, username, constants.CEOD_KEY)
-
-  room_link = None
-  if room_id is not None:
-    room_link = request.host_url + '/r/' + room_id
-    room_link = append_url_arguments(request, room_link)
     
   pc_config = make_pc_config(ice_transports)
   pc_constraints = make_pc_constraints(dtls, dscp, ipv6)
@@ -282,7 +277,10 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
     'wss_url': wss_url,
     'wss_post_url': wss_post_url
   }
+
   if room_id is not None:
+    room_link = request.host_url + '/r/' + room_id
+    room_link = append_url_arguments(request, room_link)
     params['room_id'] = room_id
     params['room_link'] = room_link
   if client_id is not None:

--- a/samples/web/content/apprtc/apprtc.py
+++ b/samples/web/content/apprtc/apprtc.py
@@ -539,7 +539,11 @@ class RoomPage(webapp2.RequestHandler):
         self.write_response('full.html')
         return
     # Parse out room parameters from request.
-    params = get_room_parameters(self.request, room_id, None, None)
+    roomParams = get_room_parameters(self.request, room_id, None, None)
+    params = {
+      'error_messages': roomParams['error_messages'],
+      'roomId': room_id
+    }
     self.write_response('index.html', params)
 
 app = webapp2.WSGIApplication([

--- a/samples/web/content/apprtc/apprtc.py
+++ b/samples/web/content/apprtc/apprtc.py
@@ -248,7 +248,7 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
 
   room_link = None
   if room_id is not None:
-    room_link = request.host_url + '/room/' + room_id
+    room_link = request.host_url + '/r/' + room_id
     room_link = append_url_arguments(request, room_link)
     
   pc_config = make_pc_config(ice_transports)

--- a/samples/web/content/apprtc/index.html
+++ b/samples/web/content/apprtc/index.html
@@ -103,7 +103,32 @@
   <script type="text/javascript">
     var loadingParams = {
       errorMessages: {{ error_messages }},
-      roomId: '{{ roomId }}'
+      isLoopback: {{ is_loopback }},
+
+      roomId: '{{ room_id }}',
+      roomLink: '{{ room_link }}',
+
+      mediaConstraints: {{ media_constraints | safe }},
+      offerConstraints: {{ offer_constraints | safe }},
+      peerConnectionConfig: {{ pc_config | safe }},
+      peerConnectionConstraints: {{ pc_constraints | safe }},
+      turnRequestUrl: '{{ turn_url }}',
+      turnTransports: '{{ turn_transports }}',
+
+      audioSendBitrate: '{{ asbr }}',
+      audioSendCodec: '{{ audio_send_codec }}',
+      audioRecvBitrate: '{{ arbr }}',
+      audioRecvCodec: '{{ audio_receive_codec }}',
+      opusMaxPbr: '{{ opusmaxpbr }}',
+      opusFec: '{{ opusfec }}',
+      opusStereo: '{{ stereo }}',
+      videoSendBitrate: '{{ vsbr }}',
+      videoSendInitialBitrate: '{{ vsibr }}',
+      videoSendCodec: '{{ video_send_codec }}',
+      videoRecvBitrate: '{{ vrbr }}',
+      videoRecvCodec: '{{ video_receive_codec }}',
+      wssUrl: '{{ wss_url }}',
+      wssPostUrl: '{{ wss_post_url }}'
     };
 
     var appController;

--- a/samples/web/content/apprtc/index.html
+++ b/samples/web/content/apprtc/index.html
@@ -101,34 +101,9 @@
 
 {% if not chromeapp %}
   <script type="text/javascript">
-    var params = {
+    var loadingParams = {
       errorMessages: {{ error_messages }},
-      isLoopback: {{ is_loopback }},
-
-      roomId: '{{ room_id }}',
-      roomLink: '{{ room_link }}',
-
-      mediaConstraints: {{ media_constraints | safe }},
-      offerConstraints: {{ offer_constraints | safe }},
-      peerConnectionConfig: {{ pc_config | safe }},
-      peerConnectionConstraints: {{ pc_constraints | safe }},
-      turnRequestUrl: '{{ turn_url }}',
-      turnTransports: '{{ turn_transports }}',
-
-      audioSendBitrate: '{{ asbr }}',
-      audioSendCodec: '{{ audio_send_codec }}',
-      audioRecvBitrate: '{{ arbr }}',
-      audioRecvCodec: '{{ audio_receive_codec }}',
-      opusMaxPbr: '{{ opusmaxpbr }}',
-      opusFec: '{{ opusfec }}',
-      opusStereo: '{{ stereo }}',
-      videoSendBitrate: '{{ vsbr }}',
-      videoSendInitialBitrate: '{{ vsibr }}',
-      videoSendCodec: '{{ video_send_codec }}',
-      videoRecvBitrate: '{{ vrbr }}',
-      videoRecvCodec: '{{ video_receive_codec }}',
-      wssUrl: '{{ wss_url }}',
-      wssPostUrl: '{{ wss_post_url }}'
+      roomId: '{{ roomId }}'
     };
 
     var appController;
@@ -142,7 +117,7 @@
         document.addEventListener('webkitvisibilitychange', onVisibilityChange);
         return;
       }
-      appController = new AppController(params);
+      appController = new AppController(loadingParams);
     }
 
     function onVisibilityChange() {

--- a/samples/web/content/apprtc/js/appcontroller.js
+++ b/samples/web/content/apprtc/js/appcontroller.js
@@ -67,23 +67,24 @@ var AppController = function(loadingParams) {
       UI_CONSTANTS.fullscreenOnSvg, UI_CONSTANTS.fullscreenOffSvg);
 
   this.loadingParams_ = loadingParams;
-  var paramsPromise = Promise.resolve(JSON.stringify({}));
+  var paramsPromise = Promise.resolve({});
   if (this.loadingParams_.paramsFunction)
   {
-    // Fetch params from server.
+    // If we have a paramsFunction value, we need to call it
+    // and use the returned values to merge with the passed
+    // in params. In the Chrome app, this is used to initialize
+    // the app with params from the server.
     paramsPromise = this.loadingParams_.paramsFunction();
   }
 
   Promise.resolve(paramsPromise).then(function(newParams) {
-    // Merge newly retrieved params with loadingParams
+    // Merge newly retrieved params with loadingParams.
     if (newParams) {
       Object.keys(newParams).forEach(function(key) {
         this.loadingParams_[key] = newParams[key];
       }.bind(this));
     }
-  }.bind(this)).catch(function(error) {
-    trace('Initializing; error getting params from server: ' + error.message);
-  }.bind(this)).then(function() {
+    
     // Proceed with call set up.
     this.roomLink_ = '';
 
@@ -123,14 +124,16 @@ var AppController = function(loadingParams) {
     window.onbeforeunload = this.call_.hangup.bind(this.call_);
     document.onkeypress = this.onKeyPress_.bind(this);
     window.onmousemove = this.showIcons_.bind(this);
+    
+    $(UI_CONSTANTS.muteAudioSvg).onclick = this.toggleAudioMute_.bind(this);
+    $(UI_CONSTANTS.muteVideoSvg).onclick = this.toggleVideoMute_.bind(this);
+    $(UI_CONSTANTS.fullscreenSvg).onclick = this.toggleFullScreen_.bind(this);
+    $(UI_CONSTANTS.hangupSvg).onclick = this.hangup_.bind(this);
+  
+    setUpFullScreen();
+  }.bind(this)).catch(function(error) {
+    trace('Error initializing: ' + error.message);
   }.bind(this));
-  
-  $(UI_CONSTANTS.muteAudioSvg).onclick = this.toggleAudioMute_.bind(this);
-  $(UI_CONSTANTS.muteVideoSvg).onclick = this.toggleVideoMute_.bind(this);
-  $(UI_CONSTANTS.fullscreenSvg).onclick = this.toggleFullScreen_.bind(this);
-  $(UI_CONSTANTS.hangupSvg).onclick = this.hangup_.bind(this);
-  
-  setUpFullScreen();
 };
 
 AppController.prototype.hangup_ = function() {

--- a/samples/web/content/apprtc/js/appcontroller.js
+++ b/samples/web/content/apprtc/js/appcontroller.js
@@ -45,8 +45,9 @@ var UI_CONSTANTS = {
 };
 
 // The controller that connects the Call with the UI.
-var AppController = function(params) {
-  trace('Initializing; room=' + params.roomId + '.');
+var AppController = function(loadingParams) {
+  trace('Initializing; server= ' + loadingParams.roomServer + '.');
+  trace('Initializing; room=' + loadingParams.roomId + '.');
 
   this.hangupSvg_ = $(UI_CONSTANTS.hangupSvg);
   this.icons_ = $(UI_CONSTANTS.icons);
@@ -56,6 +57,7 @@ var AppController = function(params) {
   this.statusDiv_ = $(UI_CONSTANTS.statusDiv);
   this.remoteVideo_ = $(UI_CONSTANTS.remoteVideo);
   this.videosDiv_ = $(UI_CONSTANTS.videosDiv);
+  this.roomLinkHref_ = $(UI_CONSTANTS.roomLinkHref);
 
   this.muteAudioIconSet_ = new AppController.IconSet_(
       UI_CONSTANTS.muteAudioOnSvg, UI_CONSTANTS.muteAudioOffSvg);
@@ -64,15 +66,16 @@ var AppController = function(params) {
   this.fullscreenIconSet_ = new AppController.IconSet_(
       UI_CONSTANTS.fullscreenOnSvg, UI_CONSTANTS.fullscreenOffSvg);
 
-  this.params_ = params;
+  this.loadingParams_ = loadingParams;
+  this.roomLink_ = '';
 
-  this.call_ = new Call(params);
+  this.call_ = new Call(loadingParams.roomServer);
   this.infoBox_ =
       new InfoBox($(UI_CONSTANTS.infoDiv), this.remoteVideo_, this.call_);
 
   this.transitionToWaitingTimer_ = null;
 
-  var roomErrors = params.errorMessages;
+  var roomErrors = loadingParams.errorMessages;
   if (roomErrors.length > 0) {
     for (var i = 0; i < roomErrors.length; ++i) {
       this.infoBox_.pushErrorMessage(roomErrors[i]);
@@ -97,7 +100,7 @@ var AppController = function(params) {
   this.call_.onstatusmessage = this.displayStatus_.bind(this);
   this.call_.oncallerstarted = this.displaySharingInfo_.bind(this);
 
-  this.call_.start();
+  this.call_.start(loadingParams.roomId);
 
   window.onbeforeunload = this.call_.hangup.bind(this.call_);
   document.onkeypress = this.onKeyPress_.bind(this);
@@ -227,7 +230,7 @@ AppController.prototype.transitionToDone_ = function() {
   this.deactivate_(this.miniVideo_);
   this.hide_(this.hangupSvg_);
   this.displayStatus_('You have left the call. <a href=\'' +
-      this.params_.roomLink + '\'>Click here</a> to rejoin.');
+      this.roomLink_ + '\'>Click here</a> to rejoin.');
 };
 
 // Spacebar, or m: toggle audio mute.
@@ -263,7 +266,10 @@ AppController.prototype.onKeyPress_ = function(event) {
   }
 };
 
-AppController.prototype.displaySharingInfo_ = function() {
+AppController.prototype.displaySharingInfo_ = function(roomLink) {
+  this.roomLinkHref_.href = roomLink;
+  this.roomLinkHref_.text = roomLink;
+  this.roomLink_ = roomLink;
   this.activate_(this.sharingDiv_);
 };
 

--- a/samples/web/content/apprtc/js/appwindow.js
+++ b/samples/web/content/apprtc/js/appwindow.js
@@ -15,6 +15,7 @@
 // Generate random room id and connect.
 
 var roomServer = 'https://apprtc.appspot.com';
+
 var loadingParams = {
   errorMessages: [],
   roomId: randomString(9),

--- a/samples/web/content/apprtc/js/appwindow.js
+++ b/samples/web/content/apprtc/js/appwindow.js
@@ -57,6 +57,7 @@ var loadingParams = {
         trace(JSON.stringify(newParams));
         resolve(newParams);
       }).catch(function(error) {
+        trace('Initializing; error getting params from server: ' + error.message);
         reject(error);
       });
     });

--- a/samples/web/content/apprtc/js/appwindow.js
+++ b/samples/web/content/apprtc/js/appwindow.js
@@ -8,63 +8,16 @@
 
 /* More information about these options at jshint.com/docs/options */
 // Variables defined in and used from main.js.
-/* globals randomString, AppController, UI_CONSTANTS */
+/* globals randomString, AppController */
 /* exported params */
 'use strict';
 
-// Provide default params set to the values returned by apprtc.appspot.com.
-var params = {
+// Generate random room id and connect.
+
+var loadingParams = {
   errorMessages: [],
-  isLoopback: false,
-  mediaConstraints: {
-    'audio': true,
-    'video': {
-      'optional': [{
-        'minWidth': '1280'
-      }, {
-        'minHeight': '720'
-      }],
-      'mandatory': {}
-    }
-  },
-  offerConstraints: {
-    'optional': [],
-    'mandatory': {}
-  },
-  peerConnectionConfig: {
-    'iceServers': []
-  },
-  peerConnectionConstraints: {
-    'optional': [{
-      'googImprovedWifiBwe': true
-    }]
-  },
-  turnRequestUrl: 'https://computeengineondemand.appspot.com/turn?username=073557600&key=4080218913',
-  turnTransports: '',
-  audioSendBitrate: '',
-  audioSendCodec: '',
-  audioRecvBitrate: '',
-  audioRecvCodec: '',
-  isStereoscopic: '',
-  opusMaxPbr: '',
-  opusFec: '',
-  opusStereo: '',
-  videoSendBitrate: '',
-  videoSendInitialBitrate: '',
-  videoSendCodec: '',
-  videoRecvBitrate: '',
-  videoRecvCodec: '',
-  wssUrl: 'wss://apprtc-ws.webrtc.org:443/ws',
-  wssPostUrl: 'https://apprtc-ws.webrtc.org:443'
+  roomId: randomString(9),
+  roomServer: 'https://apprtc.appspot.com'
 };
 
-// Generate random room id and connect.
-params.roomId = randomString(9);
-params.roomLink =  'https://apprtc.appspot.com/room/' + params.roomId;
-params.roomServer = 'https://apprtc.appspot.com';
-
-var joinRoomLink = document.querySelector(UI_CONSTANTS.roomLinkHref);
-joinRoomLink.href = params.roomLink;
-joinRoomLink.text = params.roomLink;
-
-new AppController(params);
+new AppController(loadingParams);

--- a/samples/web/content/apprtc/js/appwindow.js
+++ b/samples/web/content/apprtc/js/appwindow.js
@@ -8,16 +8,60 @@
 
 /* More information about these options at jshint.com/docs/options */
 // Variables defined in and used from main.js.
-/* globals randomString, AppController */
+/* globals randomString, AppController, sendAsyncUrlRequest, parseJSON */
 /* exported params */
 'use strict';
 
 // Generate random room id and connect.
 
+var roomServer = 'https://apprtc.appspot.com';
 var loadingParams = {
   errorMessages: [],
   roomId: randomString(9),
-  roomServer: 'https://apprtc.appspot.com'
+  roomServer: roomServer,
+  paramsFunction: function() {
+    return new Promise(function(resolve, reject) {
+      trace('Initializing; retrieving params from: ' + roomServer + '/params');
+      sendAsyncUrlRequest('GET', roomServer + '/params').then(function(result) {
+        var serverParams = parseJSON(result);
+        var newParams = {};
+        if (serverParams)
+        { 
+          // Convert from server format to expected format.
+          // TODO(tkchin): clean up response format. JSHint doesn't like it.
+          /* jshint ignore:start */
+          newParams.isLoopback = serverParams.is_loopback === 'true';
+          newParams.mediaConstraints = parseJSON(serverParams.media_constraints);
+          newParams.offerConstraints = parseJSON(serverParams.offer_constraints);
+          newParams.peerConnectionConfig = parseJSON(serverParams.pc_config);
+          newParams.peerConnectionConstraints = parseJSON(serverParams.pc_constraints);
+          newParams.turnRequestUrl = serverParams.turn_url;
+          newParams.turnTransports = serverParams.turn_transports;
+          newParams.audioSendBitrate = serverParams.asbr;
+          newParams.audioSendCodec = serverParams.audio_send_codec;
+          newParams.audioRecvBitrate = serverParams.arbr;
+          newParams.audioRecvCodec = serverParams.audio_receive_codec;
+          newParams.opusMaxPbr = serverParams.opusmaxpbr;
+          newParams.opusFec = serverParams.opusfec;
+          newParams.videoSendBitrate = serverParams.vsbr;
+          newParams.videoSendInitialBitrate = serverParams.vsibr;
+          newParams.videoSendCodec = serverParams.video_send_codec;
+          newParams.videoRecvBitrate = serverParams.vrbr;
+          newParams.videoRecvCodec = serverParams.video_receive_codec;
+          newParams.wssUrl = serverParams.wss_url;
+          newParams.wssPostUrl = serverParams.wss_post_url;
+          /* jshint ignore:end */
+          newParams.messages = serverParams.messages;
+        }
+        trace('Initializing; parameters from server: ');
+        trace(JSON.stringify(newParams));
+        resolve(newParams);
+      }).catch(function(error) {
+        reject(error);
+      });
+    });
+    
+  }
 };
 
 new AppController(loadingParams);

--- a/samples/web/content/apprtc/js/appwindow.js
+++ b/samples/web/content/apprtc/js/appwindow.js
@@ -28,6 +28,7 @@ var loadingParams = {
         if (!serverParams)
         {
           resolve(newParams);
+          return;
         }
         
         // Convert from server format to expected format.
@@ -64,7 +65,6 @@ var loadingParams = {
         reject(error);
       });
     });
-    
   }
 };
 

--- a/samples/web/content/apprtc/js/appwindow.js
+++ b/samples/web/content/apprtc/js/appwindow.js
@@ -25,34 +25,37 @@ var loadingParams = {
       sendAsyncUrlRequest('GET', roomServer + '/params').then(function(result) {
         var serverParams = parseJSON(result);
         var newParams = {};
-        if (serverParams)
-        { 
-          // Convert from server format to expected format.
-          // TODO(tkchin): clean up response format. JSHint doesn't like it.
-          /* jshint ignore:start */
-          newParams.isLoopback = serverParams.is_loopback === 'true';
-          newParams.mediaConstraints = parseJSON(serverParams.media_constraints);
-          newParams.offerConstraints = parseJSON(serverParams.offer_constraints);
-          newParams.peerConnectionConfig = parseJSON(serverParams.pc_config);
-          newParams.peerConnectionConstraints = parseJSON(serverParams.pc_constraints);
-          newParams.turnRequestUrl = serverParams.turn_url;
-          newParams.turnTransports = serverParams.turn_transports;
-          newParams.audioSendBitrate = serverParams.asbr;
-          newParams.audioSendCodec = serverParams.audio_send_codec;
-          newParams.audioRecvBitrate = serverParams.arbr;
-          newParams.audioRecvCodec = serverParams.audio_receive_codec;
-          newParams.opusMaxPbr = serverParams.opusmaxpbr;
-          newParams.opusFec = serverParams.opusfec;
-          newParams.videoSendBitrate = serverParams.vsbr;
-          newParams.videoSendInitialBitrate = serverParams.vsibr;
-          newParams.videoSendCodec = serverParams.video_send_codec;
-          newParams.videoRecvBitrate = serverParams.vrbr;
-          newParams.videoRecvCodec = serverParams.video_receive_codec;
-          newParams.wssUrl = serverParams.wss_url;
-          newParams.wssPostUrl = serverParams.wss_post_url;
-          /* jshint ignore:end */
-          newParams.messages = serverParams.messages;
+        if (!serverParams)
+        {
+          resolve(newParams);
         }
+        
+        // Convert from server format to expected format.
+        // TODO(tkchin): clean up response format. JSHint doesn't like it.
+        /* jshint ignore:start */
+        newParams.isLoopback = serverParams.is_loopback === 'true';
+        newParams.mediaConstraints = parseJSON(serverParams.media_constraints);
+        newParams.offerConstraints = parseJSON(serverParams.offer_constraints);
+        newParams.peerConnectionConfig = parseJSON(serverParams.pc_config);
+        newParams.peerConnectionConstraints = parseJSON(serverParams.pc_constraints);
+        newParams.turnRequestUrl = serverParams.turn_url;
+        newParams.turnTransports = serverParams.turn_transports;
+        newParams.audioSendBitrate = serverParams.asbr;
+        newParams.audioSendCodec = serverParams.audio_send_codec;
+        newParams.audioRecvBitrate = serverParams.arbr;
+        newParams.audioRecvCodec = serverParams.audio_receive_codec;
+        newParams.opusMaxPbr = serverParams.opusmaxpbr;
+        newParams.opusFec = serverParams.opusfec;
+        newParams.videoSendBitrate = serverParams.vsbr;
+        newParams.videoSendInitialBitrate = serverParams.vsibr;
+        newParams.videoSendCodec = serverParams.video_send_codec;
+        newParams.videoRecvBitrate = serverParams.vrbr;
+        newParams.videoRecvCodec = serverParams.video_receive_codec;
+        newParams.wssUrl = serverParams.wss_url;
+        newParams.wssPostUrl = serverParams.wss_post_url;
+        /* jshint ignore:end */
+        newParams.messages = serverParams.messages;
+        
         trace('Initializing; parameters from server: ');
         trace(JSON.stringify(newParams));
         resolve(newParams);

--- a/samples/web/content/apprtc/js/call.js
+++ b/samples/web/content/apprtc/js/call.js
@@ -48,7 +48,7 @@ Call.prototype.isInitiator = function() {
 Call.prototype.start = function(roomId) {
   this.connectToRoom_(roomId, this.maybeGetMedia_(), this.maybeGetTurnServers_());
   if (this.params_.isLoopback) {
-    setupLoopback();
+    setupLoopback(this.params_.wssUrl, roomId);
   }
 };
 

--- a/samples/web/content/apprtc/js/call.js
+++ b/samples/web/content/apprtc/js/call.js
@@ -161,7 +161,7 @@ Call.prototype.connectToRoom_ = function(mediaPromise, turnPromise) {
 
   // Asynchronously register with GAE.
   var registerPromise =
-      this.registerWithRoomServer_(this.params_.roomId).then(function(roomParams) {
+      this.registerWithRoomServer_().then(function(roomParams) {
         // The only difference in parameters should be clientId and isInitiator,
         // and the turn servers that we requested.
         // TODO(tkchin): clean up response format. JSHint doesn't like it.
@@ -313,13 +313,13 @@ Call.prototype.startSignaling_ = function() {
 };
 
 // Registers with GAE and returns room parameters.
-Call.prototype.registerWithRoomServer_ = function(roomId) {
+Call.prototype.registerWithRoomServer_ = function() {
   return new Promise(function(resolve, reject) {
-    if (!roomId) {
+    if (!this.params_.roomId) {
       reject(Error('Missing room id.'));
     }
     var path = this.roomServer_ + '/register/' +
-        roomId + window.location.search;
+        this.params_.roomId + window.location.search;
 
     sendAsyncUrlRequest('POST', path).then(function(response) {
       var responseObj = parseJSON(response);

--- a/samples/web/content/apprtc/js/call.js
+++ b/samples/web/content/apprtc/js/call.js
@@ -16,11 +16,11 @@
 
 'use strict';
 
-var Call = function(params) {
-  this.params_ = params;
-  this.roomServer_ = params.roomServer || '';
+var Call = function(roomServer) {
+  this.params_ = null;
+  this.roomServer_ = roomServer || '';
 
-  this.channel_ = new SignalingChannel(params.wssUrl, params.wssPostUrl);
+  this.channel_ = new SignalingChannel();
   this.channel_.onmessage = this.onRecvSignalingChannelMessage_.bind(this);
 
   this.pcClient_ = null;
@@ -45,11 +45,8 @@ Call.prototype.isInitiator = function() {
   return this.params_.isInitiator;
 };
 
-Call.prototype.start = function() {
-  this.connectToRoom_(this.maybeGetMedia_(), this.maybeGetTurnServers_());
-  if (this.params_.isLoopback) {
-    setupLoopback();
-  }
+Call.prototype.start = function(roomId) {
+  this.connectToRoom_(roomId);
 };
 
 Call.prototype.hangup = function() {
@@ -145,55 +142,82 @@ Call.prototype.toggleAudioMute = function() {
   trace('Audio ' + (audioTracks[0].enabled ? 'unmuted.' : 'muted.'));
 };
 
-// Connects client to the room. This happens by simultaneously requesting
-// media, requesting turn, and registering with GAE. Once all three of those
-// tasks is complete, the signaling process begins. At the same time, a
+// Connects client to the room. This happens by first registering with GAE.
+// After registration response is received, we have the params needed for 
+// requesting media and requesting turn. Once all three of those
+// tasks are complete, the signaling process begins. At the same time, a
 // WebSocket connection is opened using |wss_url| followed by a subsequent
 // registration once GAE registration completes.
-Call.prototype.connectToRoom_ = function(mediaPromise, turnPromise) {
+Call.prototype.connectToRoom_ = function(roomId) {
   // Asynchronously open a WebSocket connection to WSS.
-  // TODO(jiayl): We don't need to wait for the signaling channel to open before
-  // start signaling.
-  var channelPromise = this.channel_.open().catch(function(error) {
-    this.onError_('WebSocket open error: ' + error.message);
+  this.registerWithRoomServer_(roomId).then(function(roomParams) {
+    // TODO(tkchin): clean up response format. JSHint doesn't like it.
+    /* jshint ignore:start */
+    this.params_ = {};
+    this.params_.clientId = roomParams.client_id;
+    this.params_.isInitiator = roomParams.is_initiator === 'true';
+    this.params_.isLoopback = roomParams.is_loopback === 'true';
+    this.params_.roomId = roomParams.room_id;
+    this.params_.roomLink = roomParams.room_link;
+    this.params_.mediaConstraints = parseJSON(roomParams.media_constraints);
+    this.params_.offerConstraints = parseJSON(roomParams.offer_constraints);
+    this.params_.peerConnectionConfig = parseJSON(roomParams.pc_config);
+    this.params_.peerConnectionConstraints = parseJSON(roomParams.pc_constraints);
+    this.params_.turnRequestUrl = roomParams.turn_url;
+    this.params_.turnTransports = roomParams.turn_transports;
+    this.params_.audioSendBitrate = roomParams.asbr;
+    this.params_.audioSendCodec = roomParams.audio_send_codec;
+    this.params_.audioRecvBitrate = roomParams.arbr;
+    this.params_.audioRecvCodec = roomParams.audio_receive_codec;
+    this.params_.opusMaxPbr = roomParams.opusmaxpbr;
+    this.params_.opusFec = roomParams.opusfec;
+    this.params_.videoSendBitrate = roomParams.vsbr;
+    this.params_.videoSendInitialBitrate = roomParams.vsibr;
+    this.params_.videoSendCodec = roomParams.video_send_codec;
+    this.params_.videoRecvBitrate = roomParams.vrbr;
+    this.params_.videoRecvCodec = roomParams.video_receive_codec;
+    this.params_.wssUrl = roomParams.wss_url;
+    this.params_.wssPostUrl = roomParams.wss_post_url;
+     /* jshint ignore:end */
+    this.params_.messages = roomParams.messages;
+    
+    if (this.params_.isLoopback) {
+      setupLoopback();
+    }
+  }.bind(this)).catch(function(error) {
+    this.onError_('Room server register error: ' + error.message);
     return Promise.reject(error);
-  }.bind(this));
-
-  // Asynchronously register with GAE.
-  var registerPromise =
-      this.registerWithRoomServer_().then(function(roomParams) {
-        // The only difference in parameters should be clientId and isInitiator,
-        // and the turn servers that we requested.
-        // TODO(tkchin): clean up response format. JSHint doesn't like it.
-        /* jshint ignore:start */
-        this.params_.clientId = roomParams.client_id;
-        this.params_.roomId = roomParams.room_id;
-        this.params_.isInitiator = roomParams.is_initiator === 'true';
-        /* jshint ignore:end */
-        this.params_.messages = roomParams.messages;
+  }.bind(this)).then(function() {
+    var mediaPromise = this.maybeGetMedia_();
+    var turnPromise = this.maybeGetTurnServers_();
+    
+    // Asynchronously open a WebSocket connection to WSS.
+    // TODO(jiayl): We don't need to wait for the signaling channel to open before
+    // start signaling.
+    this.channel_.open(this.params_.wssUrl, this.params_.wssPostUrl).catch(function(error) {
+      this.onError_('WebSocket open error: ' + error.message);
+      return Promise.reject(error);
+    }.bind(this)).then(function() {
+      // We only register with WSS if the web socket connection is open and if we're
+      // already registered with GAE.
+      this.channel_.register(this.params_.roomId, this.params_.clientId);
+      // We only start signaling after we have registered the signaling channel
+      // and have media and TURN. Since we send candidates as soon as the peer
+      // connection generates them we need to wait for the signaling channel to be
+      // ready.
+      Promise.all([turnPromise, mediaPromise]).then(function() {
+        this.startSignaling_();
       }.bind(this)).catch(function(error) {
-        this.onError_('Room server register error: ' + error.message);
-        return Promise.reject(error);
+        this.onError_('Failed to start signaling: ' + error.message);
       }.bind(this));
-
-  // We only register with WSS if the web socket connection is open and if we're
-  // already registered with GAE.
-  Promise.all([channelPromise, registerPromise]).then(function() {
-    this.channel_.register(this.params_.roomId, this.params_.clientId);
-
-    // We only start signaling after we have registered the signaling channel
-    // and have media and TURN. Since we send candidates as soon as the peer
-    // connection generates them we need to wait for the signaling channel to be
-    // ready.
-    Promise.all([turnPromise, mediaPromise]).then(function() {
-      this.startSignaling_();
     }.bind(this)).catch(function(error) {
-      this.onError_('Failed to start signaling: ' + error.message);
+      this.onError_('WebSocket register error: ' + error.message);
     }.bind(this));
   }.bind(this)).catch(function(error) {
-    this.onError_('WebSocket register error: ' + error.message);
+    this.onError_('Error connecting to room: ' + error.message);
   }.bind(this));
 };
+
 
 // Asynchronously request user media if needed.
 Call.prototype.maybeGetMedia_ = function() {
@@ -294,7 +318,7 @@ Call.prototype.maybeCreatePcClient_ = function() {
 Call.prototype.startSignaling_ = function() {
   trace('Starting signaling.');
   if (this.isInitiator() && this.oncallerstarted) {
-    this.oncallerstarted();
+    this.oncallerstarted(this.params_.roomLink);
   }
 
   this.startTime = window.performance.now();
@@ -312,13 +336,13 @@ Call.prototype.startSignaling_ = function() {
 };
 
 // Registers with GAE and returns room parameters.
-Call.prototype.registerWithRoomServer_ = function() {
+Call.prototype.registerWithRoomServer_ = function(roomId) {
   return new Promise(function(resolve, reject) {
-    if (!this.params_.roomId) {
+    if (!roomId) {
       reject(Error('Missing room id.'));
     }
     var path = this.roomServer_ + '/register/' +
-        this.params_.roomId + window.location.search;
+        roomId + window.location.search;
 
     sendAsyncUrlRequest('POST', path).then(function(response) {
       var responseObj = parseJSON(response);

--- a/samples/web/content/apprtc/js/call.js
+++ b/samples/web/content/apprtc/js/call.js
@@ -150,7 +150,8 @@ Call.prototype.toggleAudioMute = function() {
 // tasks is complete, the signaling process begins. At the same time, a
 // WebSocket connection is opened using |wss_url| followed by a subsequent
 // registration once GAE registration completes.
-Call.prototype.connectToRoom_ = function(mediaPromise, turnPromise) {
+Call.prototype.connectToRoom_ = function(roomId, mediaPromise, turnPromise) {
+  this.params_.roomId = roomId;
   // Asynchronously open a WebSocket connection to WSS.
   // TODO(jiayl): We don't need to wait for the signaling channel to open before
   // start signaling.

--- a/samples/web/content/apprtc/js/loopback.js
+++ b/samples/web/content/apprtc/js/loopback.js
@@ -8,7 +8,6 @@
 
 /* More information about these options at jshint.com/docs/options */
 
-/* globals params */
 /* exported setupLoopback */
 
 'use strict';
@@ -20,13 +19,13 @@
 // one while in loopback. Bye is ignored because there is no work to do.
 var loopbackWebSocket = null;
 var LOOPBACK_CLIENT_ID = 'loopback_client_id';
-function setupLoopback() {
+function setupLoopback(wssUrl, roomId) {
   if (loopbackWebSocket) {
     return;
   }
   // TODO(tkchin): merge duplicate code once SignalingChannel abstraction
   // exists.
-  loopbackWebSocket = new WebSocket(params.wssUrl);
+  loopbackWebSocket = new WebSocket(wssUrl);
 
   var sendLoopbackMessage = function(message) {
     var msgString = JSON.stringify({
@@ -39,7 +38,7 @@ function setupLoopback() {
   loopbackWebSocket.onopen = function() {
     var registerMessage = {
       cmd: 'register',
-      roomid: params.roomId,
+      roomid: roomId,
       clientid: LOOPBACK_CLIENT_ID
     };
     loopbackWebSocket.send(JSON.stringify(registerMessage));

--- a/samples/web/content/apprtc/js/peerconnectionclient.js
+++ b/samples/web/content/apprtc/js/peerconnectionclient.js
@@ -181,10 +181,10 @@ PeerConnectionClient.prototype.doAnswer_ = function() {
 
 PeerConnectionClient.prototype.setLocalSdpAndNotify_ =
     function(sessionDescription) {
-  sessionDescription.sdp = maybePreferAudioReceiveCodec(sessionDescription.sdp);
-  sessionDescription.sdp = maybePreferVideoReceiveCodec(sessionDescription.sdp);
-  sessionDescription.sdp = maybeSetAudioReceiveBitRate(sessionDescription.sdp);
-  sessionDescription.sdp = maybeSetVideoReceiveBitRate(sessionDescription.sdp);
+  sessionDescription.sdp = maybePreferAudioReceiveCodec(sessionDescription.sdp, this.params_);
+  sessionDescription.sdp = maybePreferVideoReceiveCodec(sessionDescription.sdp, this.params_);
+  sessionDescription.sdp = maybeSetAudioReceiveBitRate(sessionDescription.sdp, this.params_);
+  sessionDescription.sdp = maybeSetVideoReceiveBitRate(sessionDescription.sdp, this.params_);
   this.pc_.setLocalDescription(sessionDescription,
       trace.bind(null, 'Set session description success.'),
       this.onError_.bind(this, 'setLocalDescription'));
@@ -216,11 +216,11 @@ PeerConnectionClient.prototype.setRemoteSdp_ = function(message) {
     message.sdp = setCodecParam(message.sdp, 'opus/48000', 'maxplaybackrate',
         this.params_.opusMaxPbr);
   }
-  message.sdp = maybePreferAudioSendCodec(message.sdp);
-  message.sdp = maybePreferVideoSendCodec(message.sdp);
-  message.sdp = maybeSetAudioSendBitRate(message.sdp);
-  message.sdp = maybeSetVideoSendBitRate(message.sdp);
-  message.sdp = maybeSetVideoSendInitialBitRate(message.sdp);
+  message.sdp = maybePreferAudioSendCodec(message.sdp, this.params_);
+  message.sdp = maybePreferVideoSendCodec(message.sdp, this.params_);
+  message.sdp = maybeSetAudioSendBitRate(message.sdp, this.params_);
+  message.sdp = maybeSetVideoSendBitRate(message.sdp, this.params_);
+  message.sdp = maybeSetVideoSendInitialBitRate(message.sdp, this.params_);
   this.pc_.setRemoteDescription(new RTCSessionDescription(message),
       this.onSetRemoteDescriptionSuccess_.bind(this),
       this.onError_.bind(this,'setRemoteDescription'));

--- a/samples/web/content/apprtc/js/sdputils.js
+++ b/samples/web/content/apprtc/js/sdputils.js
@@ -8,7 +8,7 @@
 
 /* More information about these options at jshint.com/docs/options */
 
-/* globals displayError, params */
+/* globals displayError */
 /* exported setCodecParam, iceCandidateType,
    maybePreferAudioReceiveCodec, maybePreferAudioSendCodec,
    maybeSetAudioReceiveBitRate, maybeSetAudioSendBitRate,
@@ -34,7 +34,7 @@ function iceCandidateType(candidateStr) {
   return candidateStr.split(' ')[7];
 }
 
-function maybeSetAudioSendBitRate(sdp) {
+function maybeSetAudioSendBitRate(sdp, params) {
   if (!params.audioSendBitrate) {
     return sdp;
   }
@@ -42,7 +42,7 @@ function maybeSetAudioSendBitRate(sdp) {
   return preferBitRate(sdp, params.audioSendBitrate, 'audio');
 }
 
-function maybeSetAudioReceiveBitRate(sdp) {
+function maybeSetAudioReceiveBitRate(sdp, params) {
   if (!params.audioRecvBitrate) {
     return sdp;
   }
@@ -50,7 +50,7 @@ function maybeSetAudioReceiveBitRate(sdp) {
   return preferBitRate(sdp, params.audioRecvBitrate, 'audio');
 }
 
-function maybeSetVideoSendBitRate(sdp) {
+function maybeSetVideoSendBitRate(sdp, params) {
   if (!params.videoSendBitrate) {
     return sdp;
   }
@@ -58,7 +58,7 @@ function maybeSetVideoSendBitRate(sdp) {
   return preferBitRate(sdp, params.videoSendBitrate, 'video');
 }
 
-function maybeSetVideoReceiveBitRate(sdp) {
+function maybeSetVideoReceiveBitRate(sdp, params) {
   if (!params.videoRecvBitrate) {
     return sdp;
   }
@@ -109,7 +109,7 @@ function preferBitRate(sdp, bitrate, mediaType) {
 // Add an a=fmtp: x-google-min-bitrate=kbps line, if videoSendInitialBitrate
 // is specified. We'll also add a x-google-min-bitrate value, since the max
 // must be >= the min.
-function maybeSetVideoSendInitialBitRate(sdp) {
+function maybeSetVideoSendInitialBitRate(sdp, params) {
   var initialBitrate = params.videoSendInitialBitrate;
   if (!initialBitrate) {
     return sdp;
@@ -146,22 +146,22 @@ function maybeSetVideoSendInitialBitRate(sdp) {
 }
 
 // Promotes |audioSendCodec| to be the first in the m=audio line, if set.
-function maybePreferAudioSendCodec(sdp) {
+function maybePreferAudioSendCodec(sdp, params) {
   return maybePreferCodec(sdp, 'audio', 'send', params.audioSendCodec);
 }
 
 // Promotes |audioRecvCodec| to be the first in the m=audio line, if set.
-function maybePreferAudioReceiveCodec(sdp) {
+function maybePreferAudioReceiveCodec(sdp, params) {
   return maybePreferCodec(sdp, 'audio', 'receive', params.audioRecvCodec);
 }
 
 // Promotes |videoSendCodec| to be the first in the m=audio line, if set.
-function maybePreferVideoSendCodec(sdp) {
+function maybePreferVideoSendCodec(sdp, params) {
   return maybePreferCodec(sdp, 'video', 'send', params.videoSendCodec);
 }
 
 // Promotes |videoRecvCodec| to be the first in the m=audio line, if set.
-function maybePreferVideoReceiveCodec(sdp) {
+function maybePreferVideoReceiveCodec(sdp, params) {
   return maybePreferCodec(sdp, 'video', 'receive', params.videoRecvCodec);
 }
 

--- a/samples/web/content/apprtc/js/sdputils.js
+++ b/samples/web/content/apprtc/js/sdputils.js
@@ -8,7 +8,7 @@
 
 /* More information about these options at jshint.com/docs/options */
 
-/* globals displayError */
+/* globals trace */
 /* exported setCodecParam, iceCandidateType,
    maybePreferAudioReceiveCodec, maybePreferAudioSendCodec,
    maybeSetAudioReceiveBitRate, maybeSetAudioSendBitRate,
@@ -73,7 +73,7 @@ function preferBitRate(sdp, bitrate, mediaType) {
   // Find m line for the given mediaType.
   var mLineIndex = findLine(sdpLines, 'm=', mediaType);
   if (mLineIndex === null) {
-    displayError('Failed to add bandwidth line to sdp, as no m-line found');
+    trace('Failed to add bandwidth line to sdp, as no m-line found');
     return sdp;
   }
 
@@ -87,7 +87,7 @@ function preferBitRate(sdp, bitrate, mediaType) {
   var cLineIndex = findLineInRange(sdpLines, mLineIndex + 1,
       nextMLineIndex, 'c=');
   if (cLineIndex === null) {
-    displayError('Failed to add bandwidth line to sdp, as no c-line found');
+    trace('Failed to add bandwidth line to sdp, as no c-line found');
     return sdp;
   }
 
@@ -120,7 +120,7 @@ function maybeSetVideoSendInitialBitRate(sdp, params) {
   var bitrate = params.videoSendBitrate;
   if (bitrate) {
     if (initialBitrate > bitrate) {
-      displayError('Clamping initial bitrate to max bitrate of ' +
+      trace('Clamping initial bitrate to max bitrate of ' +
                    bitrate + ' kbps.');
       initialBitrate = bitrate;
       params.videoSendInitialBitrate = initialBitrate;
@@ -133,7 +133,7 @@ function maybeSetVideoSendInitialBitRate(sdp, params) {
   // Search for m line.
   var mLineIndex = findLine(sdpLines, 'm=', 'video');
   if (mLineIndex === null) {
-    displayError('Failed to find video m-line');
+    trace('Failed to find video m-line');
     return sdp;
   }
 

--- a/samples/web/content/apprtc/js/signalingchannel.js
+++ b/samples/web/content/apprtc/js/signalingchannel.js
@@ -14,9 +14,9 @@
 'use strict';
 
 // This class implements a signaling channel based on WebSocket.
-var SignalingChannel = function(wssUrl, wssPostUrl) {
-  this.wssUrl_ = wssUrl;
-  this.wssPostUrl_ = wssPostUrl;
+var SignalingChannel = function() {
+  this.wssUrl_ = null;
+  this.wssPostUrl_ = null;
   this.roomId_ = null;
   this.clientId_ = null;
   this.websocket_ = null;
@@ -27,11 +27,14 @@ var SignalingChannel = function(wssUrl, wssPostUrl) {
   this.onmessage = null;
 };
 
-SignalingChannel.prototype.open = function() {
+SignalingChannel.prototype.open = function(wssUrl, wssPostUrl) {
   if (this.websocket_) {
     trace('ERROR: SignalingChannel has already opened.');
     return;
   }
+  
+  this.wssUrl_ = wssUrl;
+  this.wssPostUrl_ = wssPostUrl;
 
   trace('Opening signaling channel.');
   return new Promise(function(resolve, reject) {

--- a/samples/web/content/apprtc/js/signalingchannel.js
+++ b/samples/web/content/apprtc/js/signalingchannel.js
@@ -14,9 +14,9 @@
 'use strict';
 
 // This class implements a signaling channel based on WebSocket.
-var SignalingChannel = function() {
-  this.wssUrl_ = null;
-  this.wssPostUrl_ = null;
+var SignalingChannel = function(wssUrl, wssPostUrl) {
+  this.wssUrl_ = wssUrl;
+  this.wssPostUrl_ = wssPostUrl;
   this.roomId_ = null;
   this.clientId_ = null;
   this.websocket_ = null;
@@ -27,14 +27,11 @@ var SignalingChannel = function() {
   this.onmessage = null;
 };
 
-SignalingChannel.prototype.open = function(wssUrl, wssPostUrl) {
+SignalingChannel.prototype.open = function() {
   if (this.websocket_) {
     trace('ERROR: SignalingChannel has already opened.');
     return;
   }
-  
-  this.wssUrl_ = wssUrl;
-  this.wssPostUrl_ = wssPostUrl;
 
   trace('Opening signaling channel.');
   return new Promise(function(resolve, reject) {

--- a/samples/web/content/apprtc/js/signalingchannel_test.js
+++ b/samples/web/content/apprtc/js/signalingchannel_test.js
@@ -98,7 +98,7 @@ SignalingChannelTest.prototype.setUp = function() {
   WebSocket = MockWebSocket;
 
   this.channel =
-      new SignalingChannel(FAKE_WSS_URL, FAKE_WSS_POST_URL);
+      new SignalingChannel();
 };
 
 SignalingChannelTest.prototype.tearDown = function() {
@@ -106,7 +106,7 @@ SignalingChannelTest.prototype.tearDown = function() {
 };
 
 SignalingChannelTest.prototype.testOpenSuccess = function() {
-  var promise = this.channel.open();
+  var promise = this.channel.open(FAKE_WSS_URL, FAKE_WSS_POST_URL);
   assertEquals(1, webSockets.length);
 
   var resolved = false;
@@ -124,7 +124,7 @@ SignalingChannelTest.prototype.testOpenSuccess = function() {
 };
 
 SignalingChannelTest.prototype.testReceiveMessage = function() {
-  this.channel.open();
+  this.channel.open(FAKE_WSS_URL, FAKE_WSS_POST_URL);
   var socket = webSockets[0];
   socket.simulateOpenResult(true);
 
@@ -145,7 +145,7 @@ SignalingChannelTest.prototype.testReceiveMessage = function() {
 };
 
 SignalingChannelTest.prototype.testOpenFailure = function() {
-  var promise = this.channel.open();
+  var promise = this.channel.open(FAKE_WSS_URL, FAKE_WSS_POST_URL);
   assertEquals(1, webSockets.length);
 
   var resolved = false;
@@ -163,7 +163,7 @@ SignalingChannelTest.prototype.testOpenFailure = function() {
 };
 
 SignalingChannelTest.prototype.testRegisterBeforeOpen = function() {
-  this.channel.open();
+  this.channel.open(FAKE_WSS_URL, FAKE_WSS_POST_URL);
   this.channel.register(FAKE_ROOM_ID, FAKE_CLIENT_ID);
 
   var socket = webSockets[0];
@@ -180,7 +180,7 @@ SignalingChannelTest.prototype.testRegisterBeforeOpen = function() {
 };
 
 SignalingChannelTest.prototype.testRegisterAfterOpen = function() {
-  this.channel.open();
+  this.channel.open(FAKE_WSS_URL, FAKE_WSS_POST_URL);
   var socket = webSockets[0];
   socket.simulateOpenResult(true);
   this.channel.register(FAKE_ROOM_ID, FAKE_CLIENT_ID);
@@ -201,7 +201,7 @@ SignalingChannelTest.prototype.testSendBeforeOpen = function() {
   var realXMLHttpRequest = XMLHttpRequest;
   XMLHttpRequest = MockXMLHttpRequest;
 
-  this.channel.open();
+  this.channel.open(FAKE_WSS_URL, FAKE_WSS_POST_URL);
   this.channel.register(FAKE_ROOM_ID, FAKE_CLIENT_ID);
 
   var message = 'hello';
@@ -218,7 +218,7 @@ SignalingChannelTest.prototype.testSendBeforeOpen = function() {
 };
 
 SignalingChannelTest.prototype.testSendAfterOpen = function() {
-  this.channel.open();
+  this.channel.open(FAKE_WSS_URL, FAKE_WSS_POST_URL);
   var socket = webSockets[0];
   socket.simulateOpenResult(true);
   this.channel.register(FAKE_ROOM_ID, FAKE_CLIENT_ID);
@@ -237,7 +237,7 @@ SignalingChannelTest.prototype.testCloseAfterRegister = function() {
   var realXMLHttpRequest = XMLHttpRequest;
   XMLHttpRequest = MockXMLHttpRequest;
 
-  this.channel.open();
+  this.channel.open(FAKE_WSS_URL, FAKE_WSS_POST_URL);
   var socket = webSockets[0];
   socket.simulateOpenResult(true);
   this.channel.register(FAKE_ROOM_ID, FAKE_CLIENT_ID);
@@ -259,7 +259,7 @@ SignalingChannelTest.prototype.testCloseBeforeRegister = function() {
   var realXMLHttpRequest = XMLHttpRequest;
   XMLHttpRequest = MockXMLHttpRequest;
 
-  this.channel.open();
+  this.channel.open(FAKE_WSS_URL, FAKE_WSS_POST_URL);
   this.channel.close();
 
   assertEquals(0, xhrs.length);

--- a/samples/web/content/apprtc/js/signalingchannel_test.js
+++ b/samples/web/content/apprtc/js/signalingchannel_test.js
@@ -98,7 +98,7 @@ SignalingChannelTest.prototype.setUp = function() {
   WebSocket = MockWebSocket;
 
   this.channel =
-      new SignalingChannel();
+      new SignalingChannel(FAKE_WSS_URL, FAKE_WSS_POST_URL);
 };
 
 SignalingChannelTest.prototype.tearDown = function() {
@@ -106,7 +106,7 @@ SignalingChannelTest.prototype.tearDown = function() {
 };
 
 SignalingChannelTest.prototype.testOpenSuccess = function() {
-  var promise = this.channel.open(FAKE_WSS_URL, FAKE_WSS_POST_URL);
+  var promise = this.channel.open();
   assertEquals(1, webSockets.length);
 
   var resolved = false;
@@ -124,7 +124,7 @@ SignalingChannelTest.prototype.testOpenSuccess = function() {
 };
 
 SignalingChannelTest.prototype.testReceiveMessage = function() {
-  this.channel.open(FAKE_WSS_URL, FAKE_WSS_POST_URL);
+  this.channel.open();
   var socket = webSockets[0];
   socket.simulateOpenResult(true);
 
@@ -145,7 +145,7 @@ SignalingChannelTest.prototype.testReceiveMessage = function() {
 };
 
 SignalingChannelTest.prototype.testOpenFailure = function() {
-  var promise = this.channel.open(FAKE_WSS_URL, FAKE_WSS_POST_URL);
+  var promise = this.channel.open();
   assertEquals(1, webSockets.length);
 
   var resolved = false;
@@ -163,7 +163,7 @@ SignalingChannelTest.prototype.testOpenFailure = function() {
 };
 
 SignalingChannelTest.prototype.testRegisterBeforeOpen = function() {
-  this.channel.open(FAKE_WSS_URL, FAKE_WSS_POST_URL);
+  this.channel.open();
   this.channel.register(FAKE_ROOM_ID, FAKE_CLIENT_ID);
 
   var socket = webSockets[0];
@@ -180,7 +180,7 @@ SignalingChannelTest.prototype.testRegisterBeforeOpen = function() {
 };
 
 SignalingChannelTest.prototype.testRegisterAfterOpen = function() {
-  this.channel.open(FAKE_WSS_URL, FAKE_WSS_POST_URL);
+  this.channel.open();
   var socket = webSockets[0];
   socket.simulateOpenResult(true);
   this.channel.register(FAKE_ROOM_ID, FAKE_CLIENT_ID);
@@ -201,7 +201,7 @@ SignalingChannelTest.prototype.testSendBeforeOpen = function() {
   var realXMLHttpRequest = XMLHttpRequest;
   XMLHttpRequest = MockXMLHttpRequest;
 
-  this.channel.open(FAKE_WSS_URL, FAKE_WSS_POST_URL);
+  this.channel.open();
   this.channel.register(FAKE_ROOM_ID, FAKE_CLIENT_ID);
 
   var message = 'hello';
@@ -218,7 +218,7 @@ SignalingChannelTest.prototype.testSendBeforeOpen = function() {
 };
 
 SignalingChannelTest.prototype.testSendAfterOpen = function() {
-  this.channel.open(FAKE_WSS_URL, FAKE_WSS_POST_URL);
+  this.channel.open();
   var socket = webSockets[0];
   socket.simulateOpenResult(true);
   this.channel.register(FAKE_ROOM_ID, FAKE_CLIENT_ID);
@@ -237,7 +237,7 @@ SignalingChannelTest.prototype.testCloseAfterRegister = function() {
   var realXMLHttpRequest = XMLHttpRequest;
   XMLHttpRequest = MockXMLHttpRequest;
 
-  this.channel.open(FAKE_WSS_URL, FAKE_WSS_POST_URL);
+  this.channel.open();
   var socket = webSockets[0];
   socket.simulateOpenResult(true);
   this.channel.register(FAKE_ROOM_ID, FAKE_CLIENT_ID);
@@ -259,7 +259,7 @@ SignalingChannelTest.prototype.testCloseBeforeRegister = function() {
   var realXMLHttpRequest = XMLHttpRequest;
   XMLHttpRequest = MockXMLHttpRequest;
 
-  this.channel.open(FAKE_WSS_URL, FAKE_WSS_POST_URL);
+  this.channel.open();
   this.channel.close();
 
   assertEquals(0, xhrs.length);


### PR DESCRIPTION
Instead of using a params array from the initial html page, use the params array as returned by the /register/ call.

This will enable the Chrome app to get all of its parameters from the server instead of hard coding defaults, without adding any additional endpoints.

The most significant piece is that it required re-ordering the sequence of promises in call setup, because we needed the call to /register to happen first, so we had a params array to use in other calls. I did take into account the change today by @jiayliu to the ordering to maintain that change.

This step is in preparation for the landing page, and joining a room without requiring navigating to another page. When the browser requests /, the loadingParams can specify connect: false, and we will show the room selection UI. After they select a room, call setup proceeds as before. If the browser navigates directly to /r/#, loadingParams can specify connect: true and the call will be initiated immediately.

@jiayliu @juberti 
