### PR TITLE
Use pretty print to assist debugging.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -148,7 +148,8 @@ module.exports = function(grunt) {
         },
         options: {
           'compilation_level': 'WHITESPACE_ONLY',
-          'language_in': 'ECMASCRIPT5'
+          'language_in': 'ECMASCRIPT5',
+          'formatting': 'PRETTY_PRINT'
         },
       },
     },


### PR DESCRIPTION
Without pretty print, the javascript is all one line, making debugging in the debug build nearly impossible. With pretty print, the javascript is still all in 1 file, but is formatted into multiple lines.

@jiayliu 