### PR TITLE
Move json methods to shared util module

### DIFF
--- a/samples/web/content/apprtc/apprtc.py
+++ b/samples/web/content/apprtc/apprtc.py
@@ -17,6 +17,7 @@ import json
 import jinja2
 import threading
 import urllib
+import util
 import webapp2
 from google.appengine.api import memcache
 from google.appengine.api import urlfetch

--- a/samples/web/content/apprtc/util.py
+++ b/samples/web/content/apprtc/util.py
@@ -1,0 +1,54 @@
+#!/usr/bin/python2.4
+#
+# Copyright 2015 Google Inc. All Rights Reserved.
+
+"""AppRTC Util methods
+
+This module implements utility methods shared between other modules.
+"""
+
+import collections
+import json
+import logging
+
+from google.appengine.ext import ndb
+
+def has_msg_field(msg, field, field_type):
+  """Checks if |field| is a key in the |msg| dictionary with a value with type
+  |field_type|.
+
+  Returns True if key exists and its value is of type |field_type| and
+  non-empty if it is an Iterable.
+  """
+  return msg and field in msg and \
+      isinstance(msg[field], field_type) and \
+      (not isinstance(msg[field], collections.Iterable) or \
+       len(msg[field]) > 0)
+
+def has_msg_fields(msg, fields):
+  """Checks if all the (|field|, |field_type|) items in |fields| are valid in
+  the |msg| dictionary.
+
+  Returns True if all keys exist and their values are non-empty if they are
+  Iterable.
+  """
+  return reduce(lambda x, y: x and y,
+                map(lambda x: has_msg_field(msg, x[0], x[1]), fields))
+
+def get_message_from_json(body):
+  """Parses JSON from request body.
+
+  Returns parsed JSON object if JSON is valid and the represented object is a
+  dictionary, otherwise returns None.
+  """
+  try:
+    message = json.loads(body)
+    if isinstance(message, dict):
+      return message
+    logging.warning('Expected dictionary message'
+        + ', request=' + body)
+    return None
+  except Exception as e:
+    logging.warning('JSON load error from BindPage: error=' + str(e)
+        + ', request=' + body)
+    return None

--- a/samples/web/content/apprtc/util.py
+++ b/samples/web/content/apprtc/util.py
@@ -20,7 +20,7 @@ def has_msg_field(msg, field, field_type):
   Returns True if key exists and its value is of type |field_type| and
   non-empty if it is an Iterable.
   """
-  return msg and field in msg and \
+  return msg != None and field in msg and \
       isinstance(msg[field], field_type) and \
       (not isinstance(msg[field], collections.Iterable) or \
        len(msg[field]) > 0)

--- a/samples/web/content/apprtc/util_test.py
+++ b/samples/web/content/apprtc/util_test.py
@@ -1,0 +1,74 @@
+# Copyright 2014 Google Inc. All Rights Reserved.
+
+import unittest
+
+import util
+
+class UtilTest(unittest.TestCase):
+  def testGetMessageFromJson(self):
+    self.assertEqual(None, util.get_message_from_json(""))
+    self.assertEqual({}, util.get_message_from_json("{}"))
+    self.assertEqual(
+        {"a": "b","c": False, "d": 1, "e" : [1,2,"3"]}, 
+        util.get_message_from_json('{"a":"b","c":false,"d":1,"e":[1,2,"3"]}'))
+    
+  def testHasMsgField(self):
+    testObject = {
+      "a": False,
+      "b": "str",
+      "c": None,
+      "d": {},
+      "e": [1, 2, "3"],
+      "f": [],
+      "g": {'A': 1}
+    }
+    self.assertEqual(
+        True,
+        util.has_msg_field(testObject, "a", bool))
+    self.assertEqual(
+        False,
+        util.has_msg_field(testObject, "a", basestring))
+    self.assertEqual(
+        False,
+        util.has_msg_field(testObject, "c", bool))
+    self.assertEqual(
+        False,
+        util.has_msg_field(testObject, "d", dict))
+    self.assertEqual(
+        True,
+        util.has_msg_field(testObject, "e", list))
+    self.assertEqual(
+        False,
+        util.has_msg_field(testObject, "f", list))
+    self.assertEqual(
+        True,
+        util.has_msg_field(testObject, "g", dict))
+
+  def testHasMsgFields(self):
+    testObject = {
+      "a": False,
+      "b": "str",
+      "c": None,
+      "d": {},
+      "e": [1, 2, "3"],
+      "f": [],
+      "g": {'A': 1}
+    }
+    self.assertEqual(
+        True,
+        util.has_msg_fields(
+            testObject, 
+            (("a", bool), ("b", basestring), ("e", list))))
+    self.assertEqual(
+        False,
+        util.has_msg_fields(
+            testObject, 
+            (("a", bool), ("b", bool), ("e", list))))
+    self.assertEqual(
+        False,
+        util.has_msg_fields(
+            testObject, 
+            (("a", bool), ("h", basestring), ("e", list))))
+
+if __name__ == '__main__':
+  unittest.main()

--- a/samples/web/content/apprtc/util_test.py
+++ b/samples/web/content/apprtc/util_test.py
@@ -43,6 +43,12 @@ class UtilTest(unittest.TestCase):
     self.assertEqual(
         True,
         util.has_msg_field(testObject, "g", dict))
+    self.assertEqual(
+        False,
+        util.has_msg_field(testObject, "h", dict))
+    self.assertEqual(
+        False,
+        util.has_msg_field(None, "a", dict))
 
   def testHasMsgFields(self):
     testObject = {


### PR DESCRIPTION
Moves json methods to util module so we can use them in apprtc.py. Adds a couple of unit tests for the util methods.

Sending now as a separate PR to avoid merge conflicts with multiple people working in this code.

@tkchin @jiayliu  