### PR TITLE
Use compiled js for unit tests.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -164,9 +164,9 @@ module.exports = function(grunt) {
   grunt.loadTasks('grunt-chrome-build');
 
   // set default tasks to run when grunt is called without parameters
-  grunt.registerTask('default', ['csslint', 'htmlhint', 'jscs', 'jshint',
-                     'shell:runPythonTests', 'jstdPhantom',
-                     'closurecompiler:debug']);
+  grunt.registerTask('default', ['csslint', 'htmlhint',
+                     'jscs', 'jshint', 'shell:runPythonTests', 'jstests']);
+  grunt.registerTask('jstests', ['closurecompiler:debug', 'jstdPhantom']);
   grunt.registerTask('build', ['closurecompiler:debug', 'grunt-chrome-build']);
   // also possible to call JavaScript directly in registerTask()
   // or to call external tasks with grunt.loadTasks()

--- a/samples/web/content/apprtc/js_test_driver.conf
+++ b/samples/web/content/apprtc/js_test_driver.conf
@@ -1,28 +1,8 @@
 server: http://localhost:9876
 
-# The order of these files is important and should match
-# the order they are loaded in index.html.
-# The wildcard match *.js should catch any newly added files.
 load:
   - js/testpolyfills.js
-  - js/stats.js
-  - js/util.js
-  - js/adapter.js
-  - js/loopback.js
-  - js/signalingchannel.js
-  - js/sdputils.js
-  - js/peerconnectionclient.js
-  - js/call.js
-  - js/infobox.js
-  - js/appcontroller.js
-  - js/background.js
-  - js/*.js
-
-# appwindow.js is the Chrome App equivalent of index.html
-# and builds up the entire app. The tests don't currently
-# load any html, which breaks much of the code.
-exclude:
-  - js/appwindow.js
+  - js/compiled/apprtc.debug.js
 
 test:
   - js/*_test.js


### PR DESCRIPTION
Fix for #446 

grunt/jstdPhantom was loading all of the js twice. Once from the source files and once from the compiled file. This led to confusing situations where running grunt could fail the first time, and succeed the second time it was run, because the compile step happened at the very end.

This change does the following:
* Makes compile happen before jstdPhantom in the default target
* Adds a jstests target that does both steps
* Runs js unit tests against the compiled output

@jiayliu 